### PR TITLE
Prelude

### DIFF
--- a/exe/akaza
+++ b/exe/akaza
@@ -12,9 +12,9 @@ case ARGV
 in ['exec', path]
   Akaza.eval(File.read(path))
 in ['wsrb', path]
-  print Akaza::Ruby2ws.ruby_to_ws(File.read(path))
+  print Akaza::Ruby2ws.ruby_to_ws(File.read(path), path: path)
 in ['exec_wsrb', path]
-  ws = Akaza::Ruby2ws.ruby_to_ws(File.read(path))
+  ws = Akaza::Ruby2ws.ruby_to_ws(File.read(path), path: path)
   Akaza.eval(ws)
 else
   usage

--- a/lib/akaza/ruby2ws.rb
+++ b/lib/akaza/ruby2ws.rb
@@ -112,6 +112,9 @@ module Akaza
       [:stack, :pop],
     ].freeze
 
+    prelude_path = File.expand_path('./ruby2ws/prelude.rb', __dir__)
+    PRELUDE_AST = RubyVM::AbstractSyntaxTree.parse(File.read(prelude_path))
+
     class ParseError < StandardError; end
 
     def self.ruby_to_ws(ruby_code, path: '(eval)')
@@ -144,7 +147,6 @@ module Akaza
       end
 
       def transpile
-        ast = RubyVM::AbstractSyntaxTree.parse(@ruby_code)
         commands = []
         # define built-in functions
         define_array_shift
@@ -153,6 +155,10 @@ module Akaza
         define_array_attr_asgn
         define_hash_ref
 
+        # Prelude
+        commands.concat compile_expr(PRELUDE_AST)
+
+        ast = RubyVM::AbstractSyntaxTree.parse(@ruby_code)
         body = compile_expr(ast)
 
         # Save self for top level

--- a/lib/akaza/ruby2ws.rb
+++ b/lib/akaza/ruby2ws.rb
@@ -664,6 +664,7 @@ module Akaza
 
         # is_a?(Integer)
         commands << [:stack, :push, TYPE_INT]
+        commands << [:stack, :swap]
         commands << [:flow, :call, is_a_label]
         commands << [:flow, :jump_if_zero, is_int_label]
 
@@ -681,6 +682,8 @@ module Akaza
 
         # Other
         # TODO: raise error!
+        commands << [:stack, :push, '!'.ord]
+        commands << [:io, :write_char]
         commands << [:flow, :exit]
 
         commands << [:flow, :def, is_int_label]

--- a/lib/akaza/ruby2ws.rb
+++ b/lib/akaza/ruby2ws.rb
@@ -319,6 +319,7 @@ module Akaza
             m << [:stack, :swap]
             m << [:heap, :save]
           end
+
           m.concat(compile_expr(body))
           @lvars_stack.pop
           m << [:flow, :end]
@@ -335,6 +336,11 @@ module Akaza
         in [:BEGIN, nil]
           # skip
           # It is available in class definition.
+          commands << [:stack, :push, NIL]
+        in [:SELF]
+          self_addr = ident_to_label(:self)
+          commands << [:stack, :push, self_addr]
+          commands << [:heap, :load]
         in [:BLOCK, *children]
           children.each.with_index do |child, index|
             commands.concat(compile_expr(child))

--- a/lib/akaza/ruby2ws.rb
+++ b/lib/akaza/ruby2ws.rb
@@ -173,6 +173,8 @@ module Akaza
           commands.concat(UNWRAP_COMMANDS)
           commands << [:io, :write_char]
           commands << [:stack, :push, NIL]
+        in [:FCALL, :raise, [:ARRAY, [:STR, str], nil]]
+          commands.concat compile_raise(str, node)
         in [:VCALL, :get_as_number]
           commands << [:stack, :push, TMP_ADDR]
           commands << [:io, :read_num]

--- a/lib/akaza/ruby2ws.rb
+++ b/lib/akaza/ruby2ws.rb
@@ -311,11 +311,11 @@ module Akaza
         in [:VCALL, name]
           commands << [:stack, :push, variable_name_to_addr(:self)]
           commands << [:heap, :load]
-          commands.concat compile_call_with_recv(name, [], error_target_node: node, explicit_self: true)
+          commands.concat compile_call_with_recv(name, [], error_target_node: node, explicit_self: false)
         in [:FCALL, name, [:ARRAY, *args, nil]]
           commands << [:stack, :push, variable_name_to_addr(:self)]
           commands << [:heap, :load]
-          commands.concat compile_call_with_recv(name, args, error_target_node: node, explicit_self: true)
+          commands.concat compile_call_with_recv(name, args, error_target_node: node, explicit_self: false)
         in [:CALL, recv, name, [:ARRAY, *args, nil]]
           commands.concat compile_expr(recv)
           commands.concat compile_call_with_recv(name, args, error_target_node: recv, explicit_self: true)

--- a/lib/akaza/ruby2ws/prelude.rb
+++ b/lib/akaza/ruby2ws/prelude.rb
@@ -1,0 +1,5 @@
+class Array
+  def first
+    self[0]
+  end
+end

--- a/test/akaza/ruby2ws_test.rb
+++ b/test/akaza/ruby2ws_test.rb
@@ -643,6 +643,13 @@ class Ruby2wsTest < Minitest::Test
     RUBY
   end
 
+  def test_transpile_prelude_array_first
+    assert_eval '3', <<~RUBY
+      x = [3, 2, 1]
+      put_as_number x.first
+    RUBY
+  end
+
   def assert_eval(expected_output, code, input = StringIO.new(''))
     ws = Akaza::Ruby2ws.ruby_to_ws(code)
     out = StringIO.new

--- a/test/akaza/ruby2ws_test.rb
+++ b/test/akaza/ruby2ws_test.rb
@@ -81,6 +81,13 @@ class Ruby2wsTest < Minitest::Test
     RUBY
   end
 
+  def test_transpile_class
+    assert_eval "", <<~RUBY
+      class Integer
+      end
+    RUBY
+  end
+
   def test_transpile_lvar_to_lvar
     assert_eval "42", <<~RUBY
       x = 42

--- a/test/akaza/ruby2ws_test.rb
+++ b/test/akaza/ruby2ws_test.rb
@@ -132,7 +132,7 @@ class Ruby2wsTest < Minitest::Test
     RUBY
   end
 
-  def test_transpile_class_fcall_2
+  def test_transpile_class_fcall_unshift
     assert_eval "40", <<~RUBY
       class Array
         def prepend(x)
@@ -146,8 +146,20 @@ class Ruby2wsTest < Minitest::Test
     RUBY
   end
 
-  def test_transpile_class_braces
-    skip
+  def test_transpile_class_fcall_array_ref
+    assert_eval "y", <<~RUBY
+      class Array
+        def fetch(key)
+          self[key]
+        end
+      end
+
+      array = ['x', 'y', 'z']
+      put_as_char array.fetch(1)
+    RUBY
+  end
+
+  def test_transpile_class_fcall_hash_ref
     assert_eval "20", <<~RUBY
       class Hash
         def fetch(key)

--- a/test/akaza/ruby2ws_test.rb
+++ b/test/akaza/ruby2ws_test.rb
@@ -82,12 +82,16 @@ class Ruby2wsTest < Minitest::Test
   end
 
   def test_transpile_class
-    assert_eval "", <<~RUBY
-      class Integer
+    assert_eval "40", <<~RUBY
+      class Array
         def prepend(x)
           self.unshift(x)
         end
       end
+
+      x = []
+      x.prepend(40)
+      put_as_number x[0]
     RUBY
   end
 

--- a/test/akaza/ruby2ws_test.rb
+++ b/test/akaza/ruby2ws_test.rb
@@ -84,6 +84,9 @@ class Ruby2wsTest < Minitest::Test
   def test_transpile_class
     assert_eval "", <<~RUBY
       class Integer
+        def prepend(x)
+          self.unshift(x)
+        end
       end
     RUBY
   end

--- a/test/akaza/ruby2ws_test.rb
+++ b/test/akaza/ruby2ws_test.rb
@@ -18,6 +18,14 @@ class Ruby2wsTest < Minitest::Test
     assert_eval "a", "put_as_char 'a'"
   end
 
+  def test_transpile_raise
+    assert_eval "x(eval):2:0: Foobar (Error)\n", <<~RUBY
+      put_as_char 'x'
+      raise "Foobar"
+      put_as_char 'y'
+    RUBY
+  end
+
   def test_transpile_def
     assert_eval "42", "def put_42() put_as_number(42) end; put_42"
   end

--- a/test/akaza/ruby2ws_test.rb
+++ b/test/akaza/ruby2ws_test.rb
@@ -82,7 +82,7 @@ class Ruby2wsTest < Minitest::Test
   end
 
   def test_transpile_class
-    assert_eval "40", <<~RUBY
+    assert_eval "40,42", <<~RUBY
       class Array
         def prepend(x)
           self.unshift(x)
@@ -98,6 +98,8 @@ class Ruby2wsTest < Minitest::Test
       x = []
       x.prepend(40)
       put_as_number x[0]
+
+      put_as_char ','
 
       a = 42.wrap_array
       put_as_number a[0]

--- a/test/akaza/ruby2ws_test.rb
+++ b/test/akaza/ruby2ws_test.rb
@@ -132,6 +132,20 @@ class Ruby2wsTest < Minitest::Test
     RUBY
   end
 
+  def test_transpile_class_fcall_2
+    assert_eval "40", <<~RUBY
+      class Array
+        def prepend(x)
+          unshift(x)
+        end
+      end
+
+      x = []
+      x.prepend(40)
+      put_as_number x[0]
+    RUBY
+  end
+
   def test_transpile_class_braces
     skip
     assert_eval "20", <<~RUBY

--- a/test/akaza/ruby2ws_test.rb
+++ b/test/akaza/ruby2ws_test.rb
@@ -106,6 +106,12 @@ class Ruby2wsTest < Minitest::Test
     RUBY
   end
 
+  def test_transpile_class_error
+    assert_eval "(eval):1:0: Unknown type of receiver (Error)\n", <<~RUBY
+      nil.unknown_method
+    RUBY
+  end
+
   def test_transpile_lvar_to_lvar
     assert_eval "42", <<~RUBY
       x = 42
@@ -559,7 +565,7 @@ class Ruby2wsTest < Minitest::Test
   end
 
   def assert_eval(expected_output, code, input = StringIO.new(''))
-    ws = Akaza::Ruby2ws::Transpiler.new(code).transpile
+    ws = Akaza::Ruby2ws.ruby_to_ws(code)
     out = StringIO.new
     Akaza.eval(ws, input: input, output: out)
     assert_equal expected_output, out.string

--- a/test/akaza/ruby2ws_test.rb
+++ b/test/akaza/ruby2ws_test.rb
@@ -89,9 +89,18 @@ class Ruby2wsTest < Minitest::Test
         end
       end
 
+      class Integer
+        def wrap_array
+          [self]
+        end
+      end
+
       x = []
       x.prepend(40)
       put_as_number x[0]
+
+      a = 42.wrap_array
+      put_as_number a[0]
     RUBY
   end
 

--- a/test/akaza/ruby2ws_test.rb
+++ b/test/akaza/ruby2ws_test.rb
@@ -132,6 +132,19 @@ class Ruby2wsTest < Minitest::Test
     RUBY
   end
 
+  def test_transpile_class_fcall_shift
+    assert_eval "40", <<~RUBY
+      class Array
+        def shift2
+          shift
+        end
+      end
+
+      x = [40]
+      put_as_number x.shift2
+    RUBY
+  end
+
   def test_transpile_class_fcall_unshift
     assert_eval "40", <<~RUBY
       class Array

--- a/test/akaza/ruby2ws_test.rb
+++ b/test/akaza/ruby2ws_test.rb
@@ -114,6 +114,38 @@ class Ruby2wsTest < Minitest::Test
     RUBY
   end
 
+  def test_transpile_class_fcall_1
+    assert_eval "40", <<~RUBY
+      class Array
+        def prepend(x)
+          self.unshift(x)
+        end
+
+        def prepend2(x)
+          prepend(x)
+        end
+      end
+
+      x = []
+      x.prepend2(40)
+      put_as_number x[0]
+    RUBY
+  end
+
+  def test_transpile_class_braces
+    skip
+    assert_eval "20", <<~RUBY
+      class Hash
+        def fetch(key)
+          self[key]
+        end
+      end
+
+      hash = { 1 => 20, 3 => 40 }
+      put_as_number hash.fetch(1)
+    RUBY
+  end
+
   def test_transpile_class_error
     assert_eval "(eval):1:0: Unknown type of receiver (Error)\n", <<~RUBY
       nil.unknown_method


### PR DESCRIPTION
* Introduce extendable built-in classes
* Add prelude.rb

```ruby
# Extendable built-in classes example
class Array
  def prepend(x)
    self.unshift(x)
  end
end
```


goal
===

define all built-in method as method


- [x] `Array#unshift`
- [x] `Array#shift`
- [x] `Array#[]`
- [x] `Array#[]=`
- [x] `Hash#[]`

note: `Hash#[]=` is not implemented yet.